### PR TITLE
Fix typo and add things to Errors and Exceptions handling

### DIFF
--- a/backend/node-js/handle-errors-and-exceptions-in-javascript.s.md
+++ b/backend/node-js/handle-errors-and-exceptions-in-javascript.s.md
@@ -4,11 +4,11 @@
 
 ## Why
 
-* On scaling projects you can easily be overwhelmed by a pretty large code source. When this occurs, if you don't have a proper way to handle errors/exceptions, you could easily start raising a lot of bug or regression and spend a lot of time trying to fix it.
+* On projects that are scaling, you can easily be overwhelmed by a pretty large code source. When this occurs, if you don't have a proper way to handle errors/exceptions, you could easily start raising a lot of bugs or regressions and spend a lot of time trying to fix them.
 
 ## Definitions
 
-* First let's make the distinction between Erros and Exceptions:
+* First, let's make the distinction between Errors and Exceptions:
   - Errors are javascript objects that are thrown when something goes wrong in the code during runtime. It will usually have:
     - a `message` key containing a human readable error message
     - informations about where the error was raised like `fileName`, `lineNumber`, or even the whole `stack`
@@ -17,9 +17,9 @@
 ## Checks
 
 * Every Exceptions should be caught in a .catch statement and treated.
-* Every caught Error should be rethrown (Even if it makes your application crash, you have to see it QUICKLY)
-* Every .catch statement should take the error as argument
-* [OPTIONAL] If you have a logging system, in every .catch statement, you should log a message with the context and the whole error object
+* Every caught Error should be rethrown (Even if it makes your application crash, you have to see it QUICKLY).
+* Every .catch statement should take the error as argument.
+* [OPTIONAL] If you have a logging system, in every .catch statement, you should log a message with the context and the whole error object.
 
 
 ## Examples
@@ -33,9 +33,9 @@ myFunction().then(res => {
 })
 ```
 
-Here if myFunction throws an error, it will remain unhandled and can make my server crash without prior notice !
+Here if `myFunction` throws an error, it will remain unhandled and can make my server crash without prior notice!
 
-#### Example 2: Error no rethrown
+#### Example 2: Error not rethrown
 
 ```js
 myFunction().then(res => {
@@ -43,7 +43,7 @@ myFunction().then(res => {
 }).catch(console.log)
 ```
 
-Here if myFunction throws an error, it will be caught in the .catch statement and logged to the console logger. The problem are:
+Here if `myFunction` throws an error, it will be caught in the .catch statement and logged to the console logger. The problems are:
 - The statement
 ```js
 .catch(console.log)
@@ -56,10 +56,10 @@ is equivalent to
  ```js
  .catch(err => {return console.log(err)})
  ```
- therefore it will go in your next .then and act as if everything was normal with an undefined response...
- - You make the error disappear and it will not be caught in your next .catch
+ therefore it will step in your next `.then` and acts as if everything was normal with an undefined response...
+ - You make the error disappear and it will not be caught in your next `.catch`.
 
-#### Example 3: Error not even considered
+#### Example 3: Error not even handled
 
 ```js
 myFunction().then(res => {
@@ -69,7 +69,8 @@ myFunction().then(res => {
 })
 ```
 
-If you don't even use the error that has been caught, you are sure you don't react correctly to it.
+If you don't even use the error that has been caught, you can be almost sure that you don't handle it correctly.
+Note that you *might* want under certain circumstances to ignore the error. In this case, make sure to add a comment explaining why and be sure that you don't overlook an edge case where handling the error was necessary.
 
 ### Good Examples:
 #### Example 1: Error
@@ -79,7 +80,7 @@ myFunction(argument).then(res => {
   //Do something with res
 }).catch(error => {
   logger.log('The following Error occured when executing myFunction with argument', { error, argument })
-  return Promise.reject(err)
+  throw err
 })
 ```
 
@@ -93,6 +94,6 @@ myFunction(argument).then(res => {
     // Do something with error
   }
   logger.log('The following Error occured when executing myFunction with argument', { error, argument })
-  return Promise.reject(err)
+  throw err
 })
 ```


### PR DESCRIPTION
Nice article :)
I took a few minutes to fix a few typo that I've seen.
"scaling projects" sounded weird to me.
Also replaced `return Promise.reject` by `throw` as I think it's equivalent and more readable.